### PR TITLE
Debianize and remove > puppet3 dependencies

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,7 @@
 # Copyright 2014 3dna Corp
 #
 class graphite::config inherits graphite {
-  contain graphite::cache_globals
+  include graphite::cache_globals
 
   Concat {
     owner => $graphite::user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 # Copyright 2014 3dna Corp
 #
 class graphite (
-  $package_name                       = $graphite::params::package_name,
+  $package                            = $graphite::params::package,
   $cache_init_template                = $graphite::params::cache_init_template,
   $conf_dir                           = $graphite::params::conf_dir,
   $carbon_conf                        = "${conf_dir}/carbon.conf",
@@ -70,26 +70,26 @@ class graphite (
   # these have to be up here because order doesn't matter with puppet
   # except when it does.
   # :(
-  $enable_logrotation_bool = str2bool($enable_logrotation)
-  $enable_udp_listener_bool = str2bool($enable_udp_listener)
-  $log_listener_connections_bool = str2bool($log_listener_connections)
-  $use_insecure_unpickler_bool = str2bool($use_insecure_unpickler)
-  $use_flow_control_bool = str2bool($use_flow_control)
-  $log_updates_bool = str2bool($log_updates)
-  $log_cache_hits_bool = str2bool($log_cache_hits)
-  $log_cache_queue_sorts_bool = str2bool($log_cache_queue_sorts)
-  $whisper_autoflush_bool = str2bool($whisper_autoflush)
-  $whisper_sparse_create_bool = str2bool($whisper_sparse_create)
-  $whisper_fallocate_create_bool = str2bool($whisper_fallocate_create)
-  $whisper_lock_writes_bool = str2bool($whisper_lock_writes)
-  $use_whitelist_bool = str2bool($use_whitelist)
-  $enable_amqp_bool = str2bool($enable_amqp)
-  $amqp_verbose_bool = str2bool($amqp_verbose)
-  $amqp_metric_name_in_body_bool = str2bool($amqp_metric_name_in_body)
-  $enable_manhole_bool = str2bool($enable_manhole)
+  $enable_logrotation_bool = str2bool("$enable_logrotation")
+  $enable_udp_listener_bool = str2bool("$enable_udp_listener")
+  $log_listener_connections_bool = str2bool("$log_listener_connections")
+  $use_insecure_unpickler_bool = str2bool("$use_insecure_unpickler")
+  $use_flow_control_bool = str2bool("$use_flow_control")
+  $log_updates_bool = str2bool("$log_updates")
+  $log_cache_hits_bool = str2bool("$log_cache_hits")
+  $log_cache_queue_sorts_bool = str2bool("$log_cache_queue_sorts")
+  $whisper_autoflush_bool = str2bool("$whisper_autoflush")
+  $whisper_sparse_create_bool = str2bool("$whisper_sparse_create")
+  $whisper_fallocate_create_bool = str2bool("$whisper_fallocate_create")
+  $whisper_lock_writes_bool = str2bool("$whisper_lock_writes")
+  $use_whitelist_bool = str2bool("$use_whitelist")
+  $enable_amqp_bool = str2bool("$enable_amqp")
+  $amqp_verbose_bool = str2bool("$amqp_verbose")
+  $amqp_metric_name_in_body_bool = str2bool("$amqp_metric_name_in_body")
+  $enable_manhole_bool = str2bool("$enable_manhole")
 
   Class['graphite::install'] -> Class['graphite::config']
 
-  contain graphite::install
-  contain graphite::config
+  include graphite::install
+  include graphite::config
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@
 # Copyright 2014 3dna Corp
 #
 class graphite::params {
-  if ($::operatingsystem == 'Ubuntu') {
+  if ($::operatingsystem =~ /Ubuntu|Debian/) {
     $package = 'graphite-carbon'
     $service = 'carbon-cache'
     $conf_dir = '/etc/carbon'
@@ -19,7 +19,6 @@ class graphite::params {
     $local_data_dir = '/var/lib/graphite/whisper'
     $user = '_graphite'
     $group = '_graphite'
-    $package_name = 'graphite-carbon'
     $cache_init_template = 'graphite/init/ubuntu-init.d.erb'
   } else {
     fail("${::operatingsystem} not supported")

--- a/templates/init/ubuntu-init.d.erb
+++ b/templates/init/ubuntu-init.d.erb
@@ -1,6 +1,6 @@
 #! /bin/sh
 ### BEGIN INIT INFO
-# Provides:          carbon-cache
+# Provides:          carbon-cache-<%= @name %>
 # Required-Start:    $remote_fs $syslog $network
 # Required-Stop:     $remote_fs $syslog $network
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
This pull requests contains the following adjustments to the existing puppetcode:

* puppet2 doesn't know about "contain" but a normal "include" works
* Module can be used for Debian as well (same paths)
* Fix for "str2bool". Stringify all input parameters before calling
  str2bool.